### PR TITLE
Remove page numbers and use page count instead

### DIFF
--- a/_source/_layouts/blog_index.html
+++ b/_source/_layouts/blog_index.html
@@ -4,7 +4,7 @@ show_bottom_cta: true
 ---
 
 <section class="Blog is-index">
-	
+
 	{% for post in paginator.posts %}
 		{% capture _post_content %}
 			<p>{{ post.content | strip_html | truncatewords:75 }}</p>
@@ -12,28 +12,22 @@ show_bottom_cta: true
 		{% endcapture %}
 		{% include blog_post.html post_content=_post_content %}
 	{% endfor %}
-	
+
 	{% if paginator.total_pages > 1 %}
 	<div class="Blog-pagination">
-		
+
 		{% if paginator.previous_page %}
 		<a href="{{ paginator.previous_page_path | prepend: site.baseurl | append: '/' | replace: '//', '/' }}">&laquo; Prev</a>
 		{% endif %}
-		
-		{% for page in (1..paginator.total_pages) %}
-			{% if page == paginator.page %}
-			<em>{{ page }}</em>
-			{% elsif page == 1 %}
-			<a href="{{ paginator.previous_page_path | prepend: site.baseurl | append: '/' | replace: '//', '/' }}">{{ page }}</a>
-			{% else %}
-			<a href="{{ site.paginate_path | prepend: site.baseurl | append: '/' | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
-			{% endif %}
-		{% endfor %}
-		
+
+		<span class="page-number">
+    Page: {{ paginator.page }} of {{ paginator.total_pages }}
+  	</span>
+
 		{% if paginator.next_page %}
 		<a href="{{ paginator.next_page_path | prepend: site.baseurl | append: '/' | replace: '//', '/' }}">Next &raquo;</a>
 		{% endif %}
-		
+
 	</div>
 	{% endif %}
 


### PR DESCRIPTION
This PR makes it so the page numbers along the bottom don't widen the screen. Here's what it looks like now.

<img width="1037" alt="Screen Shot 2020-02-25 at 2 41 33 PM" src="https://user-images.githubusercontent.com/17892/75290443-93f64280-57dd-11ea-8b1e-5209886870ba.png">

After this fix, it just shows the current page number and Next.

<img width="836" alt="Screen Shot 2020-02-25 at 2 43 23 PM" src="https://user-images.githubusercontent.com/17892/75290473-a1133180-57dd-11ea-9511-5f8c45948353.png">

On page 2, it'll show Prev and Next.

<img width="856" alt="Screen Shot 2020-02-25 at 2 47 33 PM" src="https://user-images.githubusercontent.com/17892/75290592-e2a3dc80-57dd-11ea-8534-143e1d00185a.png">