### PR TITLE
Update Ionic tutorials to lock version of OktaDev Schematics

### DIFF
--- a/_source/_posts/2019-06-20-ionic-4-tutorial-user-authentication-and-registration.md
+++ b/_source/_posts/2019-06-20-ionic-4-tutorial-user-authentication-and-registration.md
@@ -112,12 +112,12 @@ Now that you have a client ID and issuer URI, you can install Angular CLI, and a
 
 ```shell
 npm i -g @angular/cli@7.3.9
-ng add @oktadev/schematics --issuer=$issuer --clientId=$clientId
+ng add @oktadev/schematics@0.7.1 --issuer=$issuer --clientId=$clientId
 ```
 
 The video below shows how this command performs the following steps:
 
-1. Adds and installs `@oktadev/schematics` as a dev dependency
+1. Adds and installs `@oktadev/schematics` as a dependency
 2. Adds [Ionic AppAuth](https://www.npmjs.com/package/ionic-appauth) as a dependency
 3. Adds [@ionic/storage](https://ionicframework.com/docs/building/storage) as a dependency
 4. Adds services, modules, and pages to `src/app/auth`

--- a/_source/_posts/2020-09-21-ionic-apple-google-signin.md
+++ b/_source/_posts/2020-09-21-ionic-apple-google-signin.md
@@ -74,7 +74,7 @@ If you're using the command line, you'll have to use your browser to adjust the 
 Run the following command to add a sign-in feature to your Ionic + Capacitor app. 
 
 ```shell
-ng add @oktadev/schematics --platform=capacitor
+ng add @oktadev/schematics@2.2.0 --platform=capacitor
 ```
 
 Running this command will prompt you for an issuer and client ID. If you used your browser to create an app, the client ID is displayed on your screen. You can find the issuer in your Okta dashboard at **API** > **Authorization Servers**. It usually looks something like `https://dev-133337.okta.com/oauth2/default`.


### PR DESCRIPTION
I'm gonna break some shit, locking the version numbers will prevent me from breaking our existing tutorials.