### PR TITLE
Fixing typo in JOSE definition

### DIFF
--- a/_source/_posts/2019-05-15-spring-boot-login-options.md
+++ b/_source/_posts/2019-05-15-spring-boot-login-options.md
@@ -396,7 +396,7 @@ dependencies {
 
 The security, Thymeleaf, and web starters are still there. However, there two new Spring starters: `oauth2-client` and `oauth2-jose`.
 
-`oauth2-client` brings in the libraries required for implementing an OAuth 2.0 client. `oauth2-jose` brings in some common libraries for signing and encryption. JOSE stands for Java Object Signing and Encryption.
+`oauth2-client` brings in the libraries required for implementing an OAuth 2.0 client. `oauth2-jose` brings in some common libraries for signing and encryption. JOSE stands for Javascript Object Signing and Encryption.
 
 The `SecurityConfiguration.java` file has been updated for OAuth login:
 


### PR DESCRIPTION
Per: https://datatracker.ietf.org/wg/jose/documents/
This should be either:
* Javascript Object Signing and Encryption (Note the lower case `s` in "script", which is how it's used in the specs)
* JSON Object Signing and Encryption (rfc7165)

This last one is odd, as this would read out to be "JavaScript Object Notation Object Signing and Encryption"

