### PR TITLE
Remove period from title, add to description

### DIFF
--- a/_source/_posts/2020-10-02-spring-session-mysql.md
+++ b/_source/_posts/2020-10-02-spring-session-mysql.md
@@ -1,10 +1,10 @@
 ---
 layout: blog_post
-title: "Easy Session Sharing in Spring Boot with Spring Session and MySQL."
+title: "Easy Session Sharing in Spring Boot with Spring Session and MySQL"
 author: jimena-garbarino
 by: contractor
 communities: [java,devops]
-description: "This tutorial shows you how to configure Spring Session to distribute your session using MySQL"
+description: "This tutorial shows you how to configure Spring Session to distribute your session using MySQL."
 tags: [java, session, spring-boot, okta, spring-session, mysql]
 tweets:
 - "Spring Boot's OAuth 2.0 and OIDC support is awesome, but what if you want to scale up with multiple instances? Spring Session to the rescue!"
@@ -14,7 +14,7 @@ image: blog/spring-session/spring-session.png
 type: conversion
 ---
 
-Session management in multi-node applications presents multiple challenges. When the architecture includes a load balancer, client requests might be routed to different servers each time, and the HTTP session might be lost. In this tutorial, we will walk you through the configuration of session sharing in a multi-node Spring Boot application.
+Session management in multi-node applications presents multiple challenges. When the architecture includes a load balancer, client requests might be routed to different servers each time, and the HTTP session might be lost. In this tutorial, I'll walk you through the configuration of session sharing in a multi-node Spring Boot application.
 
 **Prerequisites:**
 


### PR DESCRIPTION
Fixes title in https://developer.okta.com/blog/2020/10/02/spring-session-mysql, since it currently has a period in it.