### PR TITLE
Adding more verbage to authors page.

### DIFF
--- a/_source/_layouts/author.html
+++ b/_source/_layouts/author.html
@@ -35,6 +35,8 @@ layout: master
 		    </div>
 		{% endif %}
 
+    <h4>All Posts by {{ page.full_name }}</h4>
+
 	</article>
 
 	{% assign filtered_posts = site.posts | where: 'author', page.id %}


### PR DESCRIPTION
This PR adds phrasing to the author page that makes it clear that the page you're on contains a list of all posts by the given author. This has been brought up by a few different people over the last year, so this PR makes it a bit more obvious.

Below are some before/after pics of what this looks like (both for an author with and without a bio):

BEFORE

![Screenshot from 2021-02-10 14-39-09](https://user-images.githubusercontent.com/90247/107582197-08242480-6bae-11eb-837a-2c6d23333110.png)

AFTER

![Screenshot from 2021-02-10 14-38-50](https://user-images.githubusercontent.com/90247/107582214-0ce8d880-6bae-11eb-998e-1c6f4a54cf10.png)

BEFORE

![Screenshot from 2021-02-10 14-39-56](https://user-images.githubusercontent.com/90247/107582231-11ad8c80-6bae-11eb-8190-f49df00dba70.png)

AFTER

![Screenshot from 2021-02-10 14-39-34](https://user-images.githubusercontent.com/90247/107582243-15d9aa00-6bae-11eb-889a-dd40ab6e3ecf.png)
