### PR TITLE
Using ubuntu 18.04 stable

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   test-and-deploy:
     name: Test & Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2.3.4
 


### PR DESCRIPTION
Using ubuntu-18.04 as the base image for our test-and-deploy action. This should *hopefully* resolve the current broken deploy issue.