### PR TITLE
Improve RestTemplate code in HTTPS post

### DIFF
--- a/_source/_posts/2019-03-07-spring-microservices-https-oauth2.adoc
+++ b/_source/_posts/2019-03-07-spring-microservices-https-oauth2.adoc
@@ -12,6 +12,8 @@ tweets:
 - "Spring Security is awesome! Learn how it makes it possible to secure your microservice architecture's server-to-server communication."
 image: blog/microservices-service-to-service-security/boot-cloud-okta.jpg
 type: conversion
+changelog:
+- 2021-04-20: Updated code for `RestTemplate` so there are no thread-safety issues between clients. See [okta-blog#221]() to see what changed.
 ---
 :page-liquid:
 :toc: macro
@@ -205,6 +207,8 @@ mkcert -install
 mkcert localhost 127.0.0.1 ::1 `hostname` discovery
 ----
 
+TIP: I would recommend including your computer's IP address in the list above too. It seems to be necessary to get the `school-ui` project to connect to the config server when running outside of Docker.
+
 If this generates files with a number in them, rename the files so they don't have a number.
 
 [source,shell]
@@ -374,7 +378,7 @@ services:
 
 You can make sure it's working by running `docker-compose config` from your root directory.
 
-Run `mvn install` to rebuild all your Docker images with HTTPS enabled for Eureka registration. Then start all everything.
+Run `mvn clean install` to rebuild all your Docker images with HTTPS enabled for Eureka registration. Then start all everything.
 
 [source,shell]
 ----
@@ -499,6 +503,7 @@ TIP: You could create a service app on Okta that uses client credentials, but th
 
 The last step you'll need to do is modify `SchoolController` (in the `school-ui` project) to add an OAuth 2.0 access token to the request it makes to `school-server`.
 
+{% raw %}
 .Add an AccessToken to RestTemplate
 ====
 [source,java]
@@ -506,33 +511,36 @@ The last step you'll need to do is modify `SchoolController` (in the `school-ui`
 package com.okta.developer.docker_microservices.ui.controller;
 
 import com.okta.developer.docker_microservices.ui.dto.TeachingClassDto;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
-import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 @Controller
 @RequestMapping("/")
 public class SchoolController {
 
-    private final BearerTokenResolver bearerTokenResolver = new DefaultBearerTokenResolver(); // <1>
+    private final OAuth2AuthorizedClientService authorizedClientService;
     private final RestTemplate restTemplate;
 
-    public SchoolController(RestTemplateBuilder restTemplateBuilder) { // <2>
-        this.restTemplate = restTemplateBuilder.build();
+    public SchoolController(OAuth2AuthorizedClientService clientService,
+                            RestTemplate restTemplate) { // <1>
+        this.authorizedClientService = clientService;
+        this.restTemplate = restTemplate;
     }
 
     @RequestMapping("")
@@ -542,16 +550,22 @@ public class SchoolController {
 
     @GetMapping("/classes")
     @PreAuthorize("hasAuthority('SCOPE_profile')")
-    public ResponseEntity<List<TeachingClassDto>> listClasses(HttpServletRequest request) {
+    public ResponseEntity<List<TeachingClassDto>> listClasses(@AuthenticationPrincipal OAuth2AuthenticationToken authentication) { // <2>
 
-        String token = bearerTokenResolver.resolve(request); // <3>
+        OAuth2AuthorizedClient authorizedClient =
+            this.authorizedClientService.loadAuthorizedClient(
+                authentication.getAuthorizedClientRegistrationId(),
+                authentication.getName()); // <3>
+
+        OAuth2AccessToken accessToken = authorizedClient.getAccessToken();// <4>
         HttpHeaders headers = new HttpHeaders() {{
-            set("Authorization", "Bearer " + token); // <4>
+            set("Authorization", "Bearer " + accessToken.getTokenValue()); // <4>
         }};
 
         return restTemplate
             .exchange("https://school-service/class", HttpMethod.GET, new HttpEntity<String>(headers),
-                new ParameterizedTypeReference<List<TeachingClassDto>>() { });
+                new ParameterizedTypeReference<List<TeachingClassDto>>() {
+                });
     }
 }
 ----
@@ -560,6 +574,7 @@ public class SchoolController {
 <3> Get the access token from the `bearerTokenResolver`
 <4> Add the access token to the `Authorization` header
 ====
+{% endraw %}
 
 That's it! Since the `school-ui` and the `school-service` use the same OIDC app settings, the server will recognize and validate the access token (which is also a JWT), and allow access.
 
@@ -567,10 +582,12 @@ At this point, you can choose to run all your apps individually with `./mvnw spr
 
 [source,shell]
 ----
-mvn install
+mvn clean install
 docker-compose down
 docker-compose up -d
 ----
+
+NOTE: If your `school-ui` and `school-service` won't start after several attempts, add a `hostname` property to the `config` service in `docker-compose.yml` that matches the hostname you put in `.env`.
 
 == Use HTTP Basic Auth for Secure Microservice Communication with Eureka and Spring Cloud Config
 

--- a/_source/_posts/2019-03-07-spring-microservices-https-oauth2.adoc
+++ b/_source/_posts/2019-03-07-spring-microservices-https-oauth2.adoc
@@ -13,7 +13,7 @@ tweets:
 image: blog/microservices-service-to-service-security/boot-cloud-okta.jpg
 type: conversion
 changelog:
-- 2021-04-20: Updated code for `RestTemplate` so there are no thread-safety issues between clients. See [okta-blog#221]() to see what changed.
+- 2021-04-20: Updated code for `RestTemplate` so there are no thread-safety issues between clients. See [okta-blog#773](https://github.com/oktadeveloper/okta-blog/pull/773) to see what changed.
 ---
 :page-liquid:
 :toc: macro

--- a/_source/_posts/2019-03-07-spring-microservices-https-oauth2.adoc
+++ b/_source/_posts/2019-03-07-spring-microservices-https-oauth2.adoc
@@ -97,7 +97,7 @@ This project has an aggregator `pom.xml` in its root directory that will allow y
 
 [source,shell]
 ----
-mvn clean install
+mvn install
 ----
 
 TIP: If you don't have Maven installed, you can install it with https://sdkman.io/[SDKMAN!] `sdk install maven`
@@ -297,7 +297,7 @@ At this point, you should be able to start all your apps by running the followin
 [source,shell]
 ----
 source ../https.env
-./mvnw spring-boot:start
+./mvnw spring-boot:run
 ----
 
 Confirm it all works at `\https://localhost:8080`. Then kill everything with `killall java`.
@@ -374,7 +374,7 @@ services:
 
 You can make sure it's working by running `docker-compose config` from your root directory.
 
-Run `mvn clean install` to rebuild all your Docker images with HTTPS enabled for Eureka registration. Then start all everything.
+Run `mvn install` to rebuild all your Docker images with HTTPS enabled for Eureka registration. Then start all everything.
 
 [source,shell]
 ----
@@ -588,7 +588,7 @@ At this point, you can choose to run all your apps individually with `./mvnw spr
 
 [source,shell]
 ----
-mvn clean install
+mvn install
 docker-compose down
 docker-compose up -d
 ----

--- a/_source/_posts/2019-03-07-spring-microservices-https-oauth2.adoc
+++ b/_source/_posts/2019-03-07-spring-microservices-https-oauth2.adoc
@@ -13,7 +13,7 @@ tweets:
 image: blog/microservices-service-to-service-security/boot-cloud-okta.jpg
 type: conversion
 changelog:
-- 2021-04-20: Updated code for `RestTemplate` so there are no thread-safety issues between clients. See [okta-blog#773](https://github.com/oktadeveloper/okta-blog/pull/773) to see what changed.
+- 2021-04-20: Updated code for `RestTemplate` so there are no thread-safety issues between clients. See [okta-blog#773](https://github.com/oktadeveloper/okta-blog/pull/773) to see what changed. Changes to the example app can be viewed in [okta-spring-microservices-https-example#1](https://github.com/oktadeveloper/okta-spring-microservices-https-example/pull/1).
 ---
 :page-liquid:
 :toc: macro
@@ -537,8 +537,8 @@ public class SchoolController {
     private final OAuth2AuthorizedClientService authorizedClientService;
     private final RestTemplate restTemplate;
 
-    public SchoolController(OAuth2AuthorizedClientService clientService,
-                            RestTemplate restTemplate) { // <1>
+    public SchoolController(OAuth2AuthorizedClientService clientService, // <1>
+                            RestTemplate restTemplate) {
         this.authorizedClientService = clientService;
         this.restTemplate = restTemplate;
     }
@@ -550,16 +550,17 @@ public class SchoolController {
 
     @GetMapping("/classes")
     @PreAuthorize("hasAuthority('SCOPE_profile')")
-    public ResponseEntity<List<TeachingClassDto>> listClasses(@AuthenticationPrincipal OAuth2AuthenticationToken authentication) { // <2>
+    public ResponseEntity<List<TeachingClassDto>> listClasses(
+        @AuthenticationPrincipal OAuth2AuthenticationToken authentication) { // <2>
 
         OAuth2AuthorizedClient authorizedClient =
             this.authorizedClientService.loadAuthorizedClient(
                 authentication.getAuthorizedClientRegistrationId(),
                 authentication.getName()); // <3>
 
-        OAuth2AccessToken accessToken = authorizedClient.getAccessToken();// <4>
+        OAuth2AccessToken accessToken = authorizedClient.getAccessToken(); // <4>
         HttpHeaders headers = new HttpHeaders() {{
-            set("Authorization", "Bearer " + accessToken.getTokenValue()); // <4>
+            set("Authorization", "Bearer " + accessToken.getTokenValue()); // <5>
         }};
 
         return restTemplate
@@ -569,10 +570,11 @@ public class SchoolController {
     }
 }
 ----
-<1> Create a `BearerTokenResolver` to resolve the access token
-<2> Inject a `RestTemplateBuilder` into the constructor
-<3> Get the access token from the `bearerTokenResolver`
-<4> Add the access token to the `Authorization` header
+<.> Add an `OAuth2AuthorizedClientService` dependency to the constructor
+<.> Inject an `OAuth2AuthenticationToken` into the `listClasses()` method
+<.> Create an `OAuth2AuthorizedClient` from the `authentication`
+<.> Get the access token from the authorized client
+<.> Add the access token to the `Authorization` header
 ====
 {% endraw %}
 

--- a/_source/_posts/2019-03-07-spring-microservices-https-oauth2.adoc
+++ b/_source/_posts/2019-03-07-spring-microservices-https-oauth2.adoc
@@ -506,39 +506,33 @@ The last step you'll need to do is modify `SchoolController` (in the `school-ui`
 package com.okta.developer.docker_microservices.ui.controller;
 
 import com.okta.developer.docker_microservices.ui.dto.TeachingClassDto;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpRequest;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.ClientHttpRequestExecution;
-import org.springframework.http.client.ClientHttpRequestInterceptor;
-import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.ModelAndView;
 
-import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 @Controller
 @RequestMapping("/")
 public class SchoolController {
 
-    private final OAuth2AuthorizedClientService authorizedClientService;
+    private final BearerTokenResolver bearerTokenResolver = new DefaultBearerTokenResolver(); // <1>
     private final RestTemplate restTemplate;
 
-    public SchoolController(OAuth2AuthorizedClientService clientService,
-                            RestTemplate restTemplate) { // <1>
-        this.authorizedClientService = clientService;
-        this.restTemplate = restTemplate;
+    public SchoolController(RestTemplateBuilder restTemplateBuilder) { // <2>
+        this.restTemplate = restTemplateBuilder.build();
     }
 
     @RequestMapping("")
@@ -548,38 +542,23 @@ public class SchoolController {
 
     @GetMapping("/classes")
     @PreAuthorize("hasAuthority('SCOPE_profile')")
-    public ResponseEntity<List<TeachingClassDto>> listClasses(
-            @AuthenticationPrincipal OAuth2AuthenticationToken authentication) { // <2>
+    public ResponseEntity<List<TeachingClassDto>> listClasses(HttpServletRequest request) {
 
-        OAuth2AuthorizedClient authorizedClient =
-                this.authorizedClientService.loadAuthorizedClient(
-                        authentication.getAuthorizedClientRegistrationId(),
-                        authentication.getName()); // <3>
-
-        OAuth2AccessToken accessToken = authorizedClient.getAccessToken(); // <4>
-        // WARNING: This is example code that should not be used as-is in production.
-        // For production environments, it is recommended you use a RestTemplateFactory
-        // to give each user their own instance to avoid any potential security risks.
-        restTemplate.getInterceptors().add(getBearerTokenInterceptor(accessToken.getTokenValue())); // <5>
+        String token = bearerTokenResolver.resolve(request); // <3>
+        HttpHeaders headers = new HttpHeaders() {{
+            set("Authorization", "Bearer " + token); // <4>
+        }};
 
         return restTemplate
-                .exchange("https://school-service/class", HttpMethod.GET, null,
-                        new ParameterizedTypeReference<List<TeachingClassDto>>() {});
-    }
-
-    private ClientHttpRequestInterceptor getBearerTokenInterceptor(String accessToken) {
-        return (request, bytes, execution) -> {
-            request.getHeaders().add("Authorization", "Bearer " + accessToken);
-            return execution.execute(request, bytes);
-        };
+            .exchange("https://school-service/class", HttpMethod.GET, new HttpEntity<String>(headers),
+                new ParameterizedTypeReference<List<TeachingClassDto>>() { });
     }
 }
 ----
-<1> Add an `OAuth2AuthorizedClientService` dependency to the constructor
-<2> Inject an `OAuth2AuthenticationToken` into the `listClasses()` method
-<3> Create an `OAuth2AuthorizedClient` from the `authentication`
-<4> Get the access token from the authorized client
-<5> Add the access token to the `Authorization` header
+<1> Create a `BearerTokenResolver` to resolve the access token
+<2> Inject a `RestTemplateBuilder` into the constructor
+<3> Get the access token from the `bearerTokenResolver`
+<4> Add the access token to the `Authorization` header
 ====
 
 That's it! Since the `school-ui` and the `school-service` use the same OIDC app settings, the server will recognize and validate the access token (which is also a JWT), and allow access.


### PR DESCRIPTION
Removes `RestTemplate` warning in [Secure Service-to-Service Spring Microservices with HTTPS and OAuth 2.0](https://developer.okta.com/blog/2019/03/07/spring-microservices-https-oauth2). 

Example app updates in https://github.com/oktadeveloper/okta-spring-microservices-https-example/pull/1.