### PR TITLE
Remove self-service EA enablement steps from XAA blog post

### DIFF
--- a/_source/_posts/2025-09-03-cross-app-access.md
+++ b/_source/_posts/2025-09-03-cross-app-access.md
@@ -68,15 +68,12 @@ We'll create both apps in your Okta Integrator Free Plan account, grab their cli
 
 ### Enable Cross App Access in your Okta org
 
-> ⚠️ **Note:** Cross App Access is currently a **self-service Early Access (EA) feature**. It must be enabled through the Admin Console before the apps appear in the catalog. If you don't see the option right away, refresh and confirm you have the necessary admin permissions. Learn more in the [Okta documentation on managing EA and beta features](https://help.okta.com/oie/en-us/content/topics/security/manage-ea-and-beta-features.htm).
+> ⚠️ **Note:** Cross App Access is currently an **Early Access (EA) feature**. This guide covers the **OIDC** integration path and applies whether you're building a new OIDC-based application or adding XAA support to an existing one — as a resource app, a requesting app, or both.
 
-1. Sign in to your Okta Integrator Free plan account 
-2. In the **Okta Admin Console**, select **Settings > Features**  
-3. Navigate to **Early access**  
-4. Find **Cross App Access** and select **Turn on** (enable the toggle)  
-5. Refresh the Admin Console
+**To get Cross App Access EA enabled for your org:**
 
-{% img blog/cross-app-access/image9.jpg alt:"Enable Cross App Access feature in Okta Admin Console" width:"800" %}{: .center-image }
+- If you're an **Okta customer**: reach out to the customer support team
+- If you're an **ISV or hold a developer integrator org**: reach out to [developers@okta.com](mailto:developers@okta.com)
 
 ### Create the resource app (Todo0)
 

--- a/_source/_posts/2025-09-03-cross-app-access.md
+++ b/_source/_posts/2025-09-03-cross-app-access.md
@@ -14,8 +14,8 @@ tweets:
 image: blog/cross-app-access/social.jpg
 type: conversion
 changelog:
+   - 2026-06-30: Removed the self-service EA enablement steps as Cross App Access is no longer self-service. Updated the section to direct Okta customers to the customer support team and ISVs to developers@okta.com. Added a note clarifying that this guide covers the OIDC integration path. Changes to this article can be viewed in [oktadev/okta-blog#1663](https://github.com/oktadev/okta-blog/pull/1663).
   - 2026-05-22: Updated the Okta Admin Console steps to reflect the new **XAA Resource App** and **XAA Requesting App** App Catalog integrations, and the new required **Issuer URL** and **Client ID** fields. Changes to this article can be viewed in [oktadev/okta-blog#1641](https://github.com/oktadev/okta-blog/pull/1641).
-  - 2026-06-30: Removed the self-service EA enablement steps as Cross App Access is no longer self-service. Updated the section to direct Okta customers to the customer support team and ISVs to developers@okta.com. Added a note clarifying that this guide covers the OIDC integration path. Changes to this article can be viewed in [oktadev/okta-blog#1663](https://github.com/oktadev/okta-blog/pull/1663).
 ---
 
 So you want to get your AI agent in front of Okta customers or make your application securely accessible to agents — you're in the right place. Here's why it matters.

--- a/_source/_posts/2025-09-03-cross-app-access.md
+++ b/_source/_posts/2025-09-03-cross-app-access.md
@@ -15,6 +15,7 @@ image: blog/cross-app-access/social.jpg
 type: conversion
 changelog:
   - 2026-05-22: Updated the Okta Admin Console steps to reflect the new **XAA Resource App** and **XAA Requesting App** App Catalog integrations, and the new required **Issuer URL** and **Client ID** fields. Changes to this article can be viewed in [oktadev/okta-blog#1641](https://github.com/oktadev/okta-blog/pull/1641).
+  - 2026-06-30: Removed the self-service EA enablement steps as Cross App Access is no longer self-service. Updated the section to direct Okta customers to the customer support team and ISVs to developers@okta.com. Added a note clarifying that this guide covers the OIDC integration path. Changes to this article can be viewed in [oktadev/okta-blog#1663](https://github.com/oktadev/okta-blog/pull/1663).
 ---
 
 So you want to get your AI agent in front of Okta customers or make your application securely accessible to agents — you're in the right place. Here's why it matters.

--- a/_source/_posts/2025-09-03-cross-app-access.md
+++ b/_source/_posts/2025-09-03-cross-app-access.md
@@ -14,7 +14,7 @@ tweets:
 image: blog/cross-app-access/social.jpg
 type: conversion
 changelog:
-   - 2026-06-30: Removed the self-service EA enablement steps as Cross App Access is no longer self-service. Updated the section to direct Okta customers to the customer support team and ISVs to developers@okta.com. Added a note clarifying that this guide covers the OIDC integration path. Changes to this article can be viewed in [oktadev/okta-blog#1663](https://github.com/oktadev/okta-blog/pull/1663).
+  - 2026-06-30: Removed the self-service EA enablement steps as Cross App Access is no longer self-service. Updated the section to direct Okta customers to the customer support team and ISVs to developers@okta.com. Added a note clarifying that this guide covers the OIDC integration path. Changes to this article can be viewed in [oktadev/okta-blog#1663](https://github.com/oktadev/okta-blog/pull/1663).
   - 2026-05-22: Updated the Okta Admin Console steps to reflect the new **XAA Resource App** and **XAA Requesting App** App Catalog integrations, and the new required **Issuer URL** and **Client ID** fields. Changes to this article can be viewed in [oktadev/okta-blog#1641](https://github.com/oktadev/okta-blog/pull/1641).
 ---
 


### PR DESCRIPTION
## Summary

- Removed the self-service Early Access (EA) feature flag section, including the Admin Console steps and screenshot, as XAA is no longer self-service EA
- Updated the note to reflect that EA must be requested — Okta customers via customer support, ISVs via developers@okta.com
- Added context that this guide covers the OIDC integration path and applies to both new and existing OIDC-based applications